### PR TITLE
This commit fully implements the Form Request classes in `App/Http/Re…

### DIFF
--- a/app/Http/Requests/StoreCategoryRequest.php
+++ b/app/Http/Requests/StoreCategoryRequest.php
@@ -11,7 +11,7 @@ class StoreCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,7 @@ class StoreCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'title' => 'required|string|max:100',
         ];
     }
 }

--- a/app/Http/Requests/StoreSubtaskRequest.php
+++ b/app/Http/Requests/StoreSubtaskRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Task;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 
 class StoreSubtaskRequest extends FormRequest
 {
@@ -11,7 +13,8 @@ class StoreSubtaskRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        $task = Task::find($this->input('task_id'));
+        return $task && $task->user_id == Auth::id();
     }
 
     /**
@@ -22,7 +25,10 @@ class StoreSubtaskRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'task_id' => 'required|integer|exists:tasks,id',
+            'title' => 'required|string|max:150',
+            'status' => 'sometimes|boolean',
+            'order' => 'sometimes|integer',
         ];
     }
 }

--- a/app/Http/Requests/UpdateCategoryRequest.php
+++ b/app/Http/Requests/UpdateCategoryRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Category;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateCategoryRequest extends FormRequest
@@ -11,7 +12,9 @@ class UpdateCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        $category = $this->route('category');
+
+        return $category && $this->user()->can('update', $category);
     }
 
     /**
@@ -22,7 +25,7 @@ class UpdateCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'title' => 'sometimes|required|string|max:100',
         ];
     }
 }

--- a/app/Http/Requests/UpdateSubtaskRequest.php
+++ b/app/Http/Requests/UpdateSubtaskRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Subtask;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateSubtaskRequest extends FormRequest
@@ -11,7 +12,8 @@ class UpdateSubtaskRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        $subtask = $this->route('subtask');
+        return $subtask && $this->user()->can('update', $subtask);
     }
 
     /**
@@ -22,7 +24,9 @@ class UpdateSubtaskRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'title' => 'sometimes|required|string|max:150',
+            'status' => 'sometimes|boolean',
+            'order' => 'sometimes|integer',
         ];
     }
 }

--- a/app/Http/Requests/UpdateTaskRequest.php
+++ b/app/Http/Requests/UpdateTaskRequest.php
@@ -23,12 +23,12 @@ class UpdateTaskRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'title' =>'sometimes|required|string|max:150',
+            'title' => 'sometimes|required|string|max:150',
             'description' => 'nullable|string',
-            'priority' => ['sometimes|required', Rule::in(['faible', 'moyenne', 'elevee'])],
-            'status' => ['sometimes|required', Rule::in(['a_faire', 'en_cours', 'terminee'])],
+            'priority' => ['sometimes', 'required', Rule::in(['faible', 'moyenne', 'elevee'])],
+            'status' => ['sometimes', 'required', Rule::in(['a_faire', 'en_cours', 'terminee'])],
             'due_date' => 'nullable|date',
-            
+            'category_id' => ['sometimes', 'required', 'integer', Rule::exists('categories', 'id')->where('user_id', auth()->id())],
         ];
     }
 }


### PR DESCRIPTION
…quests` to provide proper validation and authorization for Categories, Tasks, and Subtasks.

Previously, the request classes for Categories and Subtasks were stubs, preventing any create or update operations. The `UpdateTaskRequest` had incorrect validation syntax and was missing a critical authorization check for `category_id`.

Key changes:
- Implemented `StoreCategoryRequest` and `UpdateCategoryRequest` with appropriate authorization and validation rules.
- Implemented `StoreSubtaskRequest` and `UpdateSubtaskRequest` with authorization and validation.
- Corrected validation rule syntax in `UpdateTaskRequest`.
- Added `category_id` validation to `UpdateTaskRequest` to ensure users can only assign tasks to their own categories.
- Leveraged existing policies for authorization in update requests.